### PR TITLE
Fix: Incorrect spawn location after death following warp to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Randomizer
 - Fixed: Removed event based door transition from Reactor Silo.
 - Fixed: Escape music now triggers properly.
+- Fixed: Respawning after warping to start now loads your most recent save location if you Game Over.
 
 ## 0.2.0 - 2025-03-01
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -65,5 +65,5 @@ memcpy equ 080A4EF0h
 memset equ 080A4F50h
 
 .definelabel Sram_CheckLoadSaveFileWithBlank, 08080968h
-.definelabel Sram_RestoreBackupSaveFileAfterReload, 0807FB48h ; Vanilla function is unused
-.definelabel DmaTransfer, 08002F1Ch ; r0=channel, r1=src, r2=dst, r3=len,[sp]=bitsize
+.definelabel Sram_RestoreBackupSaveFileAfterReload, 0807FB48h ; We completely replace this unused vanilla function
+.definelabel DmaTransfer, 08002F1Ch ; r0=channel, r1=src, r2=dst, r3=len, [sp]=bitsize

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -63,3 +63,7 @@ Sprite_CreatePlasmaDebris equ 080831C4h
 Divide equ 080A3468h
 memcpy equ 080A4EF0h
 memset equ 080A4F50h
+
+.definelabel Sram_CheckLoadSaveFileWithBlank, 08080968h
+.definelabel Sram_RestoreBackupSaveFileAfterReload, 0807FB48h ; Vanilla function is unused
+.definelabel DmaTransfer, 08002F1Ch ; r0=channel, r1=src, r2=dst, r3=len,[sp]=bitsize

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -497,6 +497,7 @@ SaveMeta_Size equ 14h
 .sym on
 
 SaveData equ 0858225Ch
+BackupSaveData equ 08582268h
 .sym off
 SaveData_Area equ 1Dh
 SaveData_Room equ 1Eh

--- a/src/randomizer/start-location.s
+++ b/src/randomizer/start-location.s
@@ -139,7 +139,7 @@
 .endfunc
 .endautoregion
 
-.org 0801F40Ah ; Editing in SavePlatformInit
+.org 0801F40Ah ; Modifying code in SavePlatformInit
 .area 0Ch, 0
     ; check if save pad should start lowered
     bl      @CheckLoadSaveOrNewGame
@@ -148,7 +148,7 @@
     b       0801F466h
 .endarea
 
-.org 08060DF8h ; Editing in CheckOnEventWithNavigationDisabled
+.org 08060DF8h ; Modifying code in CheckOnEventWithNavigationDisabled
 .area 24h
     ; check if navigation pad should start inactive
     push    { lr }
@@ -166,7 +166,7 @@
     .pool
 .endarea
 
-.org 08064600h ; editing LoadRoom
+.org 08064600h ; Modifying code in LoadRoom
 .area 0Ch, 0
     ; force recalculate bg position when loading save
 .endarea
@@ -208,12 +208,17 @@
 .endfunc
 .endautoregion
 
-; Edit gameover subroutine. This branch is called when you select "yes" to reload
+
+; Ensure Warping to Start does not overwrite your most recent save location when
+; continuing from a Game Over.
+
+; Hijack GameOver subroutine. This branch is called when you select "yes" to reload
 .org 08000634h
 .area 4
     bl      @ReloadFromGameOver
 .endarea
 
+; Copies the Backup Save over the Current Save
 .org Sram_RestoreBackupSaveFileAfterReload
 .area 0807FB84h - Sram_RestoreBackupSaveFileAfterReload, 0
     push    { lr }

--- a/src/randomizer/start-location.s
+++ b/src/randomizer/start-location.s
@@ -139,7 +139,7 @@
 .endfunc
 .endautoregion
 
-.org 0801F40Ah
+.org 0801F40Ah ; Editing in SavePlatformInit
 .area 0Ch, 0
     ; check if save pad should start lowered
     bl      @CheckLoadSaveOrNewGame
@@ -148,7 +148,7 @@
     b       0801F466h
 .endarea
 
-.org 08060DF8h
+.org 08060DF8h ; Editing in CheckOnEventWithNavigationDisabled
 .area 24h
     ; check if navigation pad should start inactive
     push    { lr }
@@ -166,13 +166,13 @@
     .pool
 .endarea
 
-.org 08064600h
+.org 08064600h ; editing LoadRoom
 .area 0Ch, 0
     ; force recalculate bg position when loading save
 .endarea
 
 .org StartingLocation
-.area 08h
+.area StartingLocation_Size
     .db     Area_MainDeck
     .db     00h
     .db     00h
@@ -205,5 +205,47 @@
     mov     r9, r3
     bl      080A0694h ; Return to where the original function would have gone
     .pool
+.endfunc
+.endautoregion
+
+; Edit gameover subroutine. This branch is called when you select "yes" to reload
+.org 08000634h
+.area 4
+    bl      @ReloadFromGameOver
+.endarea
+
+.org Sram_RestoreBackupSaveFileAfterReload
+.area 0807FB84h - Sram_RestoreBackupSaveFileAfterReload, 0
+    push    { lr }
+    sub     sp, #4
+    ldr     r1, =BackupSaveData
+    ldr     r0, =SaveSlot
+    ldrb    r0, [r0]
+    lsl     r0, #2
+    add     r1, r0
+    ldr     r1, [r1]    ; Current Backup Save
+    ldr     r2, =SaveData
+    add     r0, r2
+    ldr     r2, [r0]    ; Current Save
+    mov     r3, #SaveData_Size >> 8
+    lsl     r3, #8
+    mov     r0, #10h    ; 10h bits
+    str     r0, [sp]
+    mov     r0, #3      ; DMA 3
+    bl      DmaTransfer
+@@return:
+    add     sp, #4
+    pop     { r0 }
+    bx      r0
+    .pool
+.endarea
+
+.autoregion
+    .align 2
+.func @ReloadFromGameOver
+    push    { lr }
+    bl      Sram_RestoreBackupSaveFileAfterReload
+    bl      Sram_CheckLoadSaveFileWithBlank
+    pop     { pc }
 .endfunc
 .endautoregion

--- a/src/randomizer/start-warp.s
+++ b/src/randomizer/start-warp.s
@@ -68,6 +68,7 @@
     strh    r0, [r1, SaveData_MusicUnk2 - SaveData_MusicSlot1]
     bl      08080968h
     ldr     r1, =GameMode
+    ldrh    r0, [r1]
     cmp     r0, #0
     beq     @@intro
     mov     r0, #GameMode_InGame
@@ -98,7 +99,7 @@
     strb    r0, [r3, #6]
     nop :: nop
 
-.org 0807EE12h
+.org 0807EE12h ; Editing EasySleepMenuSubroutine
 .area 6Eh
     ldr     r4, =03001488h
     ldrb    r3, [r4, #2]

--- a/src/randomizer/start-warp.s
+++ b/src/randomizer/start-warp.s
@@ -99,7 +99,8 @@
     strb    r0, [r3, #6]
     nop :: nop
 
-.org 0807EE12h ; Editing EasySleepMenuSubroutine
+; Hijack the sleep function in EasySleepMenuSubroutine for warp to start.
+.org 0807EE12h
 .area 6Eh
     ldr     r4, =03001488h
     ldrb    r3, [r4, #2]


### PR DESCRIPTION
fixes: #192

fix dying after warping to start respawns at starting location instead of last save location
