### PR TITLE
Reveal hidden tanks as shot blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased - 2025-XX-XX
+- Changed: Hidden Tanks are now revealed when "Reveal Hidden Tiles" is enabled. They will show as a beam-weak block.
 
 ## 0.3.0 - 2025-03-15
 

--- a/inc/enums.inc
+++ b/inc/enums.inc
@@ -509,7 +509,7 @@ ClipdataTile_2x2TopRightNoReform equ 005Dh
 ClipdataTile_2x2BottomLeftNeverReform  equ 0060h
 ClipdataTile_2x2BottomRightNeverReform equ 0061h
 ClipdataTile_MissileTankHidden equ 0064h
-ClipdataTile_EngergyTankHidden equ 0065h
+ClipdataTile_EnergyTankHidden equ 0065h
 ClipdataTile_PBombTankHidden equ 0069h
 ClipdataTile_SpeedReform equ 006Bh
 ClipdataTile_2x2BottomLeftNoReform  equ 006Ch

--- a/src/qol/unhidden-breakable-tiles.s
+++ b/src/qol/unhidden-breakable-tiles.s
@@ -192,10 +192,9 @@
     .dh ClipdataTile_MissileNoReform,           ClipdataRevealed_Missile
     .dh ClipdataTile_PBomb,                     ClipdataRevealed_PBomb
     .dh ClipdataTile_ScrewAttack,               ClipdataRevealed_ScrewAttack
-    ; Not revealing tanks at this time
-    ;.dh ClipdataTile_MissileTankHidden,         801Ch
-    ;.dh ClipdataTile_EngergyTankHidden,         801Dh
-    ;.dh ClipdataTile_PBombTankHidden,           801Eh
+    .dh ClipdataTile_MissileTankHidden,         ClipdataRevealed_Weak ; 801Ch ; Maybe we change these later if we find a better way to reveal
+    .dh ClipdataTile_EngergyTankHidden,         ClipdataRevealed_Weak ; 801Dh ; tanks without needing to shoot them.
+    .dh ClipdataTile_PBombTankHidden,           ClipdataRevealed_Weak ; 801Eh
     .dh ClipdataTile_2x2TopLeftNeverReform,     ClipdataRevealed_Weak
     .dh ClipdataTile_2x2TopRightNeverReform,    ClipdataRevealed_Weak
     .dh ClipdataTile_WeakNeverReform,           ClipdataRevealed_Weak

--- a/src/qol/unhidden-breakable-tiles.s
+++ b/src/qol/unhidden-breakable-tiles.s
@@ -193,7 +193,7 @@
     .dh ClipdataTile_PBomb,                     ClipdataRevealed_PBomb
     .dh ClipdataTile_ScrewAttack,               ClipdataRevealed_ScrewAttack
     .dh ClipdataTile_MissileTankHidden,         ClipdataRevealed_Weak ; 801Ch ; Maybe we change these later if we find a better way to reveal
-    .dh ClipdataTile_EngergyTankHidden,         ClipdataRevealed_Weak ; 801Dh ; tanks without needing to shoot them.
+    .dh ClipdataTile_EnergyTankHidden,          ClipdataRevealed_Weak ; 801Dh ; tanks without needing to shoot them.
     .dh ClipdataTile_PBombTankHidden,           ClipdataRevealed_Weak ; 801Eh
     .dh ClipdataTile_2x2TopLeftNeverReform,     ClipdataRevealed_Weak
     .dh ClipdataTile_2x2TopRightNeverReform,    ClipdataRevealed_Weak


### PR DESCRIPTION
Fixes #214
This will allow hidden tanks to be revealed, but also indicate that they still need to be shot to be collectable.