### PR TITLE
Check HP after clearing timers

### DIFF
--- a/inc/enums.inc
+++ b/inc/enums.inc
@@ -190,6 +190,7 @@ Tank_Missiles equ 1
 Tank_Energy equ 2
 Tank_PowerBombs equ 3
 
+SamusPose_Dying equ 3Eh
 SamusPose_FrozenRequest equ 0FBh
 
 StandingFlag_Ground equ 00h

--- a/src/nonlinear/split-suits.s
+++ b/src/nonlinear/split-suits.s
@@ -107,6 +107,11 @@
     mov     r0, #0
     strb    r0, [r5, SamusTimers_SubzeroKnockback]
     b       @@return_true
+@@clear_timers:
+    mov     r0, #0
+    strb    r0, [r5, SamusTimers_EnvironmentalDamage]
+    strb    r0, [r5, SamusTimers_EnvironmentalDamageSfx]
+    strb    r0, [r5, SamusTimers_EnvironmentalDamageVfx]
 @@check_hp:
     ldr     r1, =SamusUpgrades
     ldrh    r0, [r1, SamusUpgrades_CurrEnergy]
@@ -115,11 +120,6 @@
 @@return_true:
     mov     r0, #1
     b       @@return
-@@clear_timers:
-    mov     r0, #0
-    strb    r0, [r5, SamusTimers_EnvironmentalDamage]
-    strb    r0, [r5, SamusTimers_EnvironmentalDamageSfx]
-    strb    r0, [r5, SamusTimers_EnvironmentalDamageVfx]
 @@return_false:
     mov     r0, #0
 @@return:

--- a/src/nonlinear/split-suits.s
+++ b/src/nonlinear/split-suits.s
@@ -13,8 +13,8 @@
     ldr     r5, =SamusTimers
     ldr     r1, =SamusState
     ldrb    r0, [r1, SamusState_Pose]
-    cmp     r0, #3Eh
-    beq     @@clear_timers
+    cmp     r0, #SamusPose_Dying
+    beq     @@return_false
     ldrh    r0, [r1, SamusState_PositionY]
     ldrh    r1, [r1, SamusState_PositionX]
     bl      08068E70h


### PR DESCRIPTION
Fixes #218

Vanilla has a bug where if you die and land on an enemy in the same frame, Samus's pose first gets set to "dying" but then gets overwritten with landing. On the next frame, the game checks if Samus has no HP in the hazard damage function (even if Samus isn't in a hazard), so her pose is set back to "dying"

Anty probably assumed there was no point in checking Samus's HP when not in a hazard