### PR TITLE
Alternate fix for major item fanfare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2025-XX-XX
 - Changed: Hidden Tanks are now revealed when "Reveal Hidden Tiles" is enabled. They will show as a beam-weak block.
+- Changed: Message box duration for major items is back to its vanilla value (the previous music track will resume faster).
 
 ### Randomizer
 - Fixed: Rooms with Event doors no longer occasionally display the incorrect lock.

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -184,13 +184,29 @@
 .endfunc
 .endarea
 
-.org 0802AAAEh
-.area 04h
-    ; prolong major item fanfare so it can't interrupt audio clips
-    ; last resort solution, but prevents several audio related bugs
-    mov     r0, #410 >> 1
-    lsl     r0, #1
-.endarea
+; Shorten major item fanfare tracks (prevents several audio related bugs
+; without having to prolong the message banner timer)
+; Track 1 (remove 45 ticks)
+.org 0825FA8Ah
+    .db 0B6h
+; Track 2 (remove 45 ticks)
+.org 0825FB57h
+    .db 0B6h
+; Track 3 (remove 35 ticks)
+.org 0825FB82h
+    .db 0B6h
+; Track 4 (remove 59 ticks)
+.org 0825FB9Eh
+    .db 0B6h
+; Track 5 (remove 25 ticks)
+.org 0825FC1Ch
+    .db 0CEh, 0B6h
+; Track 6 (remove 45 ticks)
+.org 0825FC51h
+    .db 0B6h
+; Track 7 (remove 45 ticks)
+.org 0825FC86h
+    .db 0B6h
 
 ; Obtain upgrade from tank and set message and fanfare
 .org 0806C3CEh


### PR DESCRIPTION
Fixes #183 

Shortens the major item fanfare audio tracks instead of prolonging the message box timer