### PR TITLE
fix: allocate space for an additional pointer for room names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Randomizer
 - Fixed: Rooms with Event doors no longer occasionally display the incorrect lock.
 - Fixed: Warp to Start correctly plays background music on fresh file.
+- Fixed: Tables for room names now allocate sufficient space to store name pointers.
 
 ## 0.3.0 - 2025-03-15
 

--- a/src/randomizer/room-name-display.s
+++ b/src/randomizer/room-name-display.s
@@ -71,7 +71,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
-    .dw     @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -90,7 +90,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
-    .dw     @UnknownRoom
+    .dw     @UnknownRoom, @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -111,6 +111,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -125,7 +126,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
-    .dw     @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -142,7 +143,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
-    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -160,7 +161,7 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
-    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
 .endautoregion
 
 .autoregion
@@ -176,4 +177,5 @@
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
     .dw     @UnknownRoom, @UnknownRoom, @UnknownRoom, @UnknownRoom
+    .dw     @UnknownRoom
 .endautoregion


### PR DESCRIPTION
Tables were not allocating sufficient space for room name pointers. Each table was off-by-one causing to the possibility of overwriting important data.