### PR TITLE
Fix SWJ Exploit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2025-XX-XX
 - Changed: Hidden Tanks are now revealed when "Reveal Hidden Tiles" is enabled. They will show as a beam-weak block.
 - Changed: Message box duration for major items is back to its vanilla value (the previous music track will resume faster).
+- Fixed: Removed an exploit that allowed toggling Screw Attack to give Single Walljump functionality.
 
 ### Randomizer
 - Fixed: Rooms with Event doors no longer occasionally display the incorrect lock.

--- a/inc/enums.inc
+++ b/inc/enums.inc
@@ -190,6 +190,8 @@ Tank_Missiles equ 1
 Tank_Energy equ 2
 Tank_PowerBombs equ 3
 
+SamusPose_WallJumping equ 16h
+SamusPose_ScrewAttacking equ 1Eh
 SamusPose_Dying equ 3Eh
 SamusPose_FrozenRequest equ 0FBh
 

--- a/src/main.s
+++ b/src/main.s
@@ -124,7 +124,6 @@ RevealHiddenTilesFlag equ 087FF08Ch
 .if PHYSICS
 .notice "Applying physics patches..."
 .include "src/physics/air-momentum.s"
-.include "src/physics/single-walljump.s"
 .include "src/physics/speedkeep.s"
 .endif
 

--- a/src/nonlinear/item-select.s
+++ b/src/nonlinear/item-select.s
@@ -745,6 +745,17 @@
     add     r0, r5
     ldr     r1, =UpgradeLookup
     ldrb    r0, [r1, r0]
+    ; r0 contains which upgrade is being toggled
+    ; if Screw Attack is being toggled, prevent if ScrewWJ flag is set
+    ; r2 and r3 are about to be reassigned, so safe to use.
+    cmp     r0, Upgrade_ScrewAttack
+    bne     @@finish_toggle
+    ldr     r2, =ScrewAttackWJFlag
+    ldrb    r2, [r2]
+    cmp     r2, #0
+    beq     @@finish_toggle
+    b       @@return
+@@finish_toggle:
     lsl     r0, #2
     ldr     r3, =MajorUpgradeInfo
     add     r3, r0

--- a/src/physics/single-walljump.s
+++ b/src/physics/single-walljump.s
@@ -8,13 +8,14 @@
     push    { r0-r3 }
     ldr     r2, =SamusState
     ldrb    r0, [r2, SamusState_Pose]
-    cmp     r0, #16h
+    cmp     r0, #SamusPose_WallJumping
     bne     @@default
     ; Do not set if space jump is active
     ldr     r1, =SamusUpgrades
     ldrb    r1, [r1, SamusUpgrades_SuitUpgrades]
     mov     r0, 1 << SuitUpgrade_SpaceJump
     and     r0, r1
+    cmp     r0, #0
     bne     @@default
     mov     r0, #1
     ldr     r2, =ScrewAttackWJFlag
@@ -22,7 +23,7 @@
 @@default:
     ; Always set Pose to Screw
     ldr     r2, =SamusState
-    mov     r0, #1Eh
+    mov     r0, #SamusPose_ScrewAttacking
     strb    r0, [r2, SamusState_Pose]
     pop     { r0-r3 }
     bl      0800623Ch ; Return to original code flow
@@ -47,7 +48,7 @@
     ; If pose isn't screw attack, allow, and turn flag off if it was on
     ldr     r2, =SamusState
     ldrb    r0, [r2, SamusState_Pose]
-    cmp     r0, #1Eh
+    cmp     r0, #SamusPose_ScrewAttacking
     bne     @@unsetScrewWJFlag
     ; Check Flag
     ldr     r2, =ScrewAttackWJFlag
@@ -124,7 +125,7 @@
     ; If pose isn't screw attack, turn flag off
     ldr     r2, =SamusState
     ldrb    r0, [r2, SamusState_Pose]
-    cmp     r0, #1Eh
+    cmp     r0, #SamusPose_ScrewAttacking
     bne     @@unsetScrewWJFlag
     b       @@return
 @@unsetScrewWJFlag:


### PR DESCRIPTION
Prevents the toggling of SA if the ScrewWJ Flag is set. This prevents an exploit allowing for SWJ functionality