### PR TITLE
Fix event hatch skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed: Rooms with Event doors no longer occasionally display the incorrect lock.
 - Fixed: Warp to Start correctly plays background music on fresh file.
 - Fixed: Tables for room names now allocate sufficient space to store name pointers.
+- Fixed: Event Hatches can no longer be skipped by timing movement.
 
 ## 0.3.0 - 2025-03-15
 

--- a/src/randomizer/hatch-fixes.s
+++ b/src/randomizer/hatch-fixes.s
@@ -107,7 +107,9 @@
     strb    r1, [r2, HatchData_Animation]
     b       @@loopIncrement
 @@closing:
-    ; By setting the animation flag to 3, the closing animation triggers and the hatch works correct
+    ; By setting the animation flag to 3, and status to 9, the hatch closes immediately
+    mov     r1, #9h 
+    strb    r1, [r2, HatchData_Status]
     mov     r1, #3 
     strb    r1, [r2, HatchData_Animation]
 @@loopIncrement:

--- a/src/randomizer/hatch-fixes.s
+++ b/src/randomizer/hatch-fixes.s
@@ -108,7 +108,13 @@
     b       @@loopIncrement
 @@closing:
     ; By setting the animation flag to 3, and status to 9, the hatch closes immediately
+    ; The hatch type needs to be preserved though
+    ldrb    r0, [r2, HatchData_Status]
+    ; Clear Animation Information
+    lsr     r0, #4
+    lsl     r0, #4 
     mov     r1, #9h 
+    orr     r1, r0
     strb    r1, [r2, HatchData_Status]
     mov     r1, #3 
     strb    r1, [r2, HatchData_Animation]


### PR DESCRIPTION
Event Hatches can no longer be skipped by running at them with correct timing. This causes the animation to be 1-frame instead of displaying the whole thing.

Fixes #224 