### PR TITLE
bugfix: play go-mode music when picking up last required item.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed: Warp to Start correctly plays background music on fresh file.
 - Fixed: Tables for room names now allocate sufficient space to store name pointers.
 - Fixed: Event Hatches can no longer be skipped by timing movement.
+- Changed: Go-Mode music now starts immediately after closing the message box if your last required pickup is on Main Deck.
 
 ## 0.3.0 - 2025-03-15
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -26,6 +26,7 @@ SetClipdata equ 0806C82Ch
 SpawnParticleEffect equ 080730E4h
 SetEvent equ 08074890h
 
+FinishCollectingTank equ 0806C498h
 SetTankAsCollected equ 0806CCF8h
 RemoveCollectedTanks equ 0806CE40h
 MinimapSetCollectedItems equ 08075884h

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -343,6 +343,8 @@ TankCounter_MaxTotalPowerBombTanks equ 0Ah
 TankCounter_CurrTotalPowerBombTanks equ 0Bh
 .sym on
 
+LastTankCollected equ 03004FA4h
+
 MusicInfo equ 030019D0h
 .sym off
 MusicInfo_Slot1Track equ 1Ch

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -208,6 +208,10 @@
 
 .func CheckTrueGoMode
     push    { lr }
+    mov     r0, #Event_GoMode
+    bl      CheckEvent
+    cmp     r0, #1
+    bne     @@return_false
     mov     r0, #Event_EscapeSequence
     bl      CheckEvent
     cmp     r0, #01

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -205,6 +205,32 @@
     pop     { r4-r5, pc }
     .pool
 .endfunc
+
+.func CheckTrueGoMode
+    push    { lr }
+    mov     r0, #Event_EscapeSequence
+    bl      CheckEvent
+    cmp     r0, #01
+    beq     @@return_false
+    ldr     r1, =SamusUpgrades
+    ldrb    r0, [r1, SamusUpgrades_BeamUpgrades]
+    lsl     r0, #1Fh
+    lsr     r0, #1Fh
+    cmp     r0, #1
+    bne     @@return_false
+    ldrb    r0, [r1, SamusUpgrades_ExplosiveUpgrades]
+    lsl     r0, #1Fh
+    lsr     r0, #1Fh
+    cmp     r0, #1
+    bne     @@return_false
+@@return_true:
+    mov     r0, #1
+    pop     { pc }
+@@return_false:
+    mov     r0, #0
+    pop     { pc }
+    .pool
+.endfunc
 .endautoregion
 
 .org 080798F8h

--- a/src/nonlinear/music.s
+++ b/src/nonlinear/music.s
@@ -95,7 +95,7 @@
 @@goModeMusic:
 ; Checks if in Observation Deck to play pre-SAX ambience
     cmp     r5, Area_MainDeck
-    bne     @@finalMission
+    bne     @@areaSwitch
     cmp     r6, #0Dh ; operations room
     beq     @@preSaxMusic
     cmp     r6, #52h ; operations room

--- a/src/nonlinear/music.s
+++ b/src/nonlinear/music.s
@@ -95,7 +95,7 @@
 @@goModeMusic:
 ; Checks if in Observation Deck to play pre-SAX ambience
     cmp     r5, Area_MainDeck
-    bne     @@areaSwitch
+    bne     @@finalMission
     cmp     r6, #0Dh ; operations room
     beq     @@preSaxMusic
     cmp     r6, #52h ; operations room
@@ -121,15 +121,7 @@
     b       @@playMusic
 ; Checks if player has charge and missiles to signal true go mode
 @@finalMission:
-    ldr     r1, =SamusUpgrades
-    ldrb    r0, [r1, SamusUpgrades_BeamUpgrades]
-    lsl     r0, #1Fh
-    lsr     r0, #1Fh
-    cmp     r0, #1
-    bne     @@areaSwitch
-    ldrb    r0, [r1, SamusUpgrades_ExplosiveUpgrades]
-    lsl     r0, #1Fh
-    lsr     r0, #1Fh
+    bl      CheckTrueGoMode
     cmp     r0, #1
     bne     @@areaSwitch
     mov     r0, MusicTrack_FinalMission

--- a/src/nonlinear/room-states.s
+++ b/src/nonlinear/room-states.s
@@ -18,6 +18,8 @@
 .autoregion
     .align 2
 .func CheckEvent
+    ; WARNING: registers are not preserved. Take caution when relying on values
+    ; prior to calling this function.
     ; Returns one if the passed event should be considered active or complete,
     ; otherwise returns zero.
     cmp     r0, #Event_GameEnd
@@ -373,9 +375,9 @@
     ; room states: S0-0D => S0-55
 .if RANDOMIZER
     ldrb    r0, [r2, PermanentUpgrades_InfantMetroids]
-    ldr     r1, =RequiredMetroidCount
-    ldrb    r1, [r1]
-    cmp     r0, r1
+    ldr     r2, =RequiredMetroidCount
+    ldrb    r2, [r2]
+    cmp     r0, r2
     bge     @@return_true
     b       @@return_false
 .else

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -251,7 +251,7 @@
     .align 2
 @MessageBoxClosingHijack:
     push    { lr }
-    ldr     r0, =03004FA4h
+    ldr     r0, =LastTankCollected
     ldrh    r0, [r0]
     cmp     r0, #0
     beq     @@checkGoMode

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -241,15 +241,36 @@
 ; check temporary tank data for tank deletion
 .org 0802ABB0h
 .area 10h, 0
-    ldr     r0, =03004FA4h
-    ldrh    r0, [r0]
-    cmp     r0, #0
-    beq     0802ABC0h
-    bl      0806C498h
+    bl      @MessageBoxClosingHijack
 .endarea
     .skip 12h
     pop     { pc }
     .pool
+
+.autoregion
+    .align 2
+@MessageBoxClosingHijack:
+    push    { lr }
+    ldr     r0, =03004FA4h
+    ldrh    r0, [r0]
+    cmp     r0, #0
+    beq     @@checkGoMode
+    bl      FinishCollectingTank
+@@checkGoMode:
+    mov     r0, #Event_GoMode
+    bl      CheckEvent
+    cmp     r0, #0
+    beq     @@return
+    bl      CheckTrueGoMode
+    cmp     r0, #1
+    bne     @@return
+    mov     r0, MusicTrack_FinalMission
+    mov     r1, MusicType_MainDeck
+    bl      Music_Play
+@@return:
+    pop     { pc }
+    .pool
+.endautoregion
 
 ; cleanup temporary tank data
 .org 0806C4E2h


### PR DESCRIPTION
Fixes #157

Music will change when the message box is closed.

For testing, you will need to run RDV with mars-patcher-py installed as editable with the patches generated from `make dist` saved in `mars-patcher-py/src/mars_patcher/data/patches/mf_u/asm/`

Here are 3 RDV games with go-mode items in sector 2:
One in Kago Room, one on the Level 1 Security room, one on Nettori. These should be sufficient for all cases where you receive an item from a minor location, a major location, and a boss. You should be spawned with all items except your go-mode. You are provided 100 missiles, and 10 e-tanks to make testing easier.
[Issue157.zip](https://github.com/user-attachments/files/19677482/Issue157.zip)

Things to note: I have not tested all cases where the message box might appear, but I believe I have covered at least the major points where it does.
