### PR TITLE
fix: Add current area check for true go-mode for proper music trigger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2025-XX-XX
 
+### Randomizer
+- Fixed: Go-Mode Music should no longer start when closing miscellaneous banners, such as save or recharge banners, in sectors other than Main Deck.
+
 ## 0.4.0 - 2025-04-21
 - Changed: Hidden Tanks are now revealed when "Reveal Hidden Tiles" is enabled. They will show as a beam-weak block.
 - Changed: Message box duration for major items is back to its vanilla value (the previous music track will resume faster).

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -208,10 +208,6 @@
 
 .func CheckTrueGoMode
     push    { lr }
-    ldr     r1, =CurrArea
-    ldrb    r1, [r1]
-    cmp     r1, Area_MainDeck
-    bne     @@return_false
     mov     r0, #Event_GoMode
     bl      CheckEvent
     cmp     r0, #1

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -208,6 +208,10 @@
 
 .func CheckTrueGoMode
     push    { lr }
+    ldr     r1, =CurrArea
+    ldrb    r1, [r1]
+    cmp     r1, Area_MainDeck
+    bne     @@return_false
     mov     r0, #Event_GoMode
     bl      CheckEvent
     cmp     r0, #1

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -264,6 +264,10 @@
     bl      CheckTrueGoMode
     cmp     r0, #1
     bne     @@return
+    ldr     r0, =CurrArea
+    ldrb    r0, [r0]
+    cmp     r0, Area_MainDeck
+    bne     @@return
     mov     r0, MusicTrack_FinalMission
     mov     r1, MusicType_MainDeck
     bl      Music_Play


### PR DESCRIPTION
Fix #239

This fix ensures that we are on Main Deck when checking go-mode music trigger. Otherwise it has the possibility of triggering on save/recharge rooms or other miscellaneous message banners when it may not be expected.