### PR TITLE
fix: exclude operations deck save and recharge rooms from triggering go-mode music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2025-XX-XX
 
+### Randomizer
+- Fixed: Go-mode music no longer triggers from save/recharge station in operations deck. Main Deck Data room can still trigger go-mode music, even if it is not a go-mode item.
+
 ## 0.4.2 - 2025-04-25
 
 ### Randomizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2025-XX-XX
 
 ### Randomizer
-- Fixed: Go-mode music no longer triggers from save/recharge station in operations deck. Main Deck Data room can still trigger go-mode music, even if it is not a go-mode item.
+- Fixed: Go-mode music no longer triggers from save/recharge station in operations deck. Main Deck Data room will play SA-X Ambience instead of Go-Mode music if go-mode conditions are satisifed.
 
 ## 0.4.2 - 2025-04-25
 

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -252,6 +252,12 @@
     ldrb    r0, [r0]
     cmp     r0, Area_MainDeck
     bne     @@return
+    ldr     r0, =CurrRoom
+    ldrb    r0, [r0]
+    cmp     r0, 2Ch ; operations deck recharge room
+    beq     @@return
+    cmp     r0, 51h ; operations deck recharge room
+    beq     @@return
     mov     r0, MusicTrack_FinalMission
     mov     r1, MusicType_MainDeck
     bl      Music_Play

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -254,12 +254,20 @@
     bne     @@return
     ldr     r0, =CurrRoom
     ldrb    r0, [r0]
-    cmp     r0, 2Ch ; operations deck recharge room
+    cmp     r0, 27h ; operations deck data room
+    beq     @@play_sax_ambience
+    cmp     r0, 2Ch ; operations deck save room
     beq     @@return
     cmp     r0, 51h ; operations deck recharge room
     beq     @@return
+@@play_final_mission:
     mov     r0, MusicTrack_FinalMission
     mov     r1, MusicType_MainDeck
+    b       @@play_music
+@@play_sax_ambience:
+    mov     r0, MusicTrack_SaxHiding
+    mov     r1, MusicType_BossAmbience
+@@play_music:
     bl      Music_Play
 @@return:
     pop     { pc }


### PR DESCRIPTION
Fixes #255

Makes it so the recharge and save rooms in the operations deck do not trigger go-mode music.
When downloading an item in data room, if you already have go-mode, or it is your go-mode item, play SA-X ambience music.