### PR TITLE
Do not trigger music if the SA-X has already been defeated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added: The events for cooling the Boiler, freeing the Animals, and turning on Auxiliary Power now give items.
 
 ### Randomizer
-- Fixed: Go-mode music no longer triggers from save/recharge station in operations deck. Main Deck Data room will play SA-X Ambience instead of Go-Mode music if go-mode conditions are satisifed.
+- Fixed: Go-mode music no longer triggers from save/recharge station in operations deck. Main Deck Data room will play SA-X Ambience instead of Go-Mode music if go-mode conditions are satisifed. Main Deck Data room will not change the music if the SA-X has been defeated.
 
 ## 0.4.2 - 2025-04-25
 

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -265,6 +265,10 @@
     mov     r1, MusicType_MainDeck
     b       @@play_music
 @@play_sax_ambience:
+    mov     r0, #Event_SaxDefeated
+    bl      CheckEvent
+    cmp     r0, #1
+    beq     @@return
     mov     r0, MusicTrack_SaxHiding
     mov     r1, MusicType_BossAmbience
 @@play_music:


### PR DESCRIPTION
This check should prevent SA-X music from triggering in the data room if you have already defeated the SA-X