### PR TITLE
Specify location jingles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Randomizer
 - Added: Provided a message ID (0x38h) which will display the Infant Metroid message.
+- Added: Provide the ability to specify what jingle an item location plays.
 
 ### Visual
 - Changed: Stronger/Blue Zoros, Stronger/Red Zeelas, Super Missile Gerons, Stronger/Golden Scizer and Stronger/Golden Pirates all have slight visual adjustments made for accessibility reasons.

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -666,7 +666,8 @@ MajorUpgradeInfo_Message equ 02h
 MajorLocations_Len equ 23
 MajorLocation_Upgrade equ 00h
 MajorLocation_Message equ 01h
-MajorLocation_Size equ 02h
+MajorLocation_Jingle equ 02h
+MajorLocation_Size equ 04h
 .sym on
 
 .sym off
@@ -679,7 +680,8 @@ MinorLocation_YPos equ 04h
 MinorLocation_Upgrade equ 05h
 MinorLocation_Sprite equ 06h
 MinorLocation_Message equ 07h
-MinorLocation_Size equ 08h
+MinorLocation_Jingle equ 08h
+MinorLocation_Size equ 10h
 .sym on
 
 .sym off
@@ -702,4 +704,10 @@ StoredRevealedTiles_Type equ 0
 StoredRevealedTiles_YPos equ 2
 StoredRevealedTiles_XPos equ 3
 StoredRevealedTiles_Size equ 4
+.sym on
+
+ItemJingleFlag equ 03005670h
+.sym off
+MinorItemJingle equ 0
+MajorItemJingle equ 1
 .sym on

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -12,6 +12,11 @@
     ldr     r1, =MajorLocationItems
     lsl     r0, log2(MajorLocation_Size)
     add     r1, r0
+    ; Store Location Jingle
+    ldrb    r0, [r1, MajorLocation_Jingle]
+    ldr     r3, =ItemJingleFlag
+    strb    r0, [r3]
+    ; Load Location Information
     ldrb    r0, [r1, MajorLocation_Upgrade]
     ldrb    r1, [r1, MajorLocation_Message]
     b       ObtainUpgrade
@@ -22,6 +27,11 @@
     ldr     r1, =MinorLocations
     lsl     r0, log2(MinorLocation_Size)
     add     r1, r0
+    ; Store Location Jingle
+    ldrb    r0, [r1, MinorLocation_Jingle]
+    ldr     r3, =ItemJingleFlag
+    strb    r0, [r3]
+    ; Load Location Information
     ldrb    r0, [r1, MinorLocation_Upgrade]
     ldrb    r1, [r1, MinorLocation_Message]
     b       ObtainUpgrade
@@ -337,30 +347,30 @@ RequiredMetroidCount:
 
 .autoregion
 MajorLocationItems:
-        .db     Upgrade_Missiles, Message_Auto
-        .db     Upgrade_MorphBall, Message_Auto
-        .db     Upgrade_ChargeBeam, Message_Auto
-        .db     Upgrade_SecurityLevel1, Message_Auto
-        .db     Upgrade_Bombs, Message_Auto
-        .db     Upgrade_HiJump, Message_Auto
-        .db     Upgrade_Speedbooster, Message_Auto
-        .db     Upgrade_SecurityLevel2, Message_Auto
-        .db     Upgrade_SuperMissiles, Message_Auto
-        .db     Upgrade_VariaSuit, Message_Auto
-        .db     Upgrade_SecurityLevel3, Message_Auto
-        .db     Upgrade_IceMissiles, Message_Auto
-        .db     Upgrade_WideBeam, Message_Auto
-        .db     Upgrade_PowerBombs, Message_Auto
-        .db     Upgrade_SpaceJump, Message_Auto
-        .db     Upgrade_PlasmaBeam, Message_Auto
-        .db     Upgrade_GravitySuit, Message_Auto
-        .db     Upgrade_SecurityLevel4, Message_Auto
-        .db     Upgrade_DiffusionMissiles, Message_Auto
-        .db     Upgrade_WaveBeam, Message_Auto
-        .db     Upgrade_ScrewAttack, Message_Auto
-        .db     Upgrade_InfantMetroid, Message_Auto
-        .db     Upgrade_InfantMetroid, Message_Auto
-        .db     Upgrade_InfantMetroid, Message_Auto
+        .db     Upgrade_Missiles, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_MorphBall, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_ChargeBeam, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SecurityLevel1, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_Bombs, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_HiJump, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_Speedbooster, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SecurityLevel2, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SuperMissiles, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_VariaSuit, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SecurityLevel3, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_IceMissiles, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_WideBeam, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_PowerBombs, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SpaceJump, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_PlasmaBeam, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_GravitySuit, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_SecurityLevel4, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_DiffusionMissiles, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_WaveBeam, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_ScrewAttack, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_InfantMetroid, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_InfantMetroid, Message_Auto, MajorItemJingle, 0h
+        .db     Upgrade_InfantMetroid, Message_Auto, MajorItemJingle, 0h
 .endautoregion
 
 .org TankIncrementsPointer

--- a/src/nonlinear/messages.s
+++ b/src/nonlinear/messages.s
@@ -166,6 +166,58 @@
 .endfunc
 .endautoregion
 
+.org 0802AAAEh
+.area 06h
+    bl  SetMajorLocationMessageBoxTimer
+    nop
+.endarea
+
+.org 0802AB04h
+.area 04h
+    bl  SetMinorLocationMessageBoxTimer
+.endarea
+
+.autoregion
+.func SetMajorLocationMessageBoxTimer
+    ldr     r4, =ItemJingleFlag
+    ldrb    r0, [r4]
+    cmp     r0, #0
+    beq     @@minorJingle
+    ; prolong major item fanfare so it can't interrupt audio clips
+    ; last resort solution, but prevents several audio related bugs
+    mov     r0, #410 >> 1
+    lsl     r0, #1
+    b       @@return
+@@minorJingle:
+    mov     r0, #05Ah
+@@return:    
+    ldr     r4, =CurrentSprite
+    strh    r0, [r4, Sprite_XParasiteTimer]
+    bx      lr
+.endfunc
+.pool
+.endautoregion
+
+.autoregion
+.func SetMinorLocationMessageBoxTimer
+    ldr     r1, =ItemJingleFlag
+    ldrb    r0, [r1]
+    cmp     r0, #0
+    beq     @@minorJingle
+    ; prolong major item fanfare so it can't interrupt audio clips
+    ; last resort solution, but prevents several audio related bugs
+    mov     r0, #410 >> 1
+    lsl     r0, #1
+    b       @@return
+@@minorJingle:
+    mov     r0, #05Ah
+@@return:
+    ldr     r1, =CurrentSprite
+    mov     pc, lr
+.endfunc
+.pool
+.endautoregion
+
 .org 0802AA3Ch
 .area 0Eh
     ; play task complete fanfare

--- a/src/nonlinear/messages.s
+++ b/src/nonlinear/messages.s
@@ -143,10 +143,28 @@
 
 .org 0802AA2Ch
 .area 04h
-    ; play upgrade collected fanfare
-    cmp     r6, #0
-    bne     0802AA3Ch
+    bl      DetermineJingle
 .endarea
+
+.autoregion
+.align 4
+; Add one to offsets to account for THUMB
+.func DetermineJingle
+    push    { r1 }
+    ldr     r1, =ItemJingleFlag
+    ldrb    r0, [r1]
+    cmp     r0, #0
+    beq     @@minorJingle
+    ldr     r0, =0802AA31h ; Will Play Major Jingle
+    b       @@return
+@@minorJingle:
+    ldr     r0, =0802AA3Dh
+@@return:
+    pop     { r1 }
+    bx      r0
+.pool
+.endfunc
+.endautoregion
 
 .org 0802AA3Ch
 .area 0Eh

--- a/src/optimization/item-check.s
+++ b/src/optimization/item-check.s
@@ -618,610 +618,714 @@ MinorLocations:
     .db     0Dh, 0Eh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room11:
     .db     Area_MainDeck, 11h, 0
     .db     09h, 14h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room23:
     .db     Area_MainDeck, 23h, 0
     .db     0Eh, 41h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room26:
     .db     Area_MainDeck, 26h, 0
     .db     35h, 0Ah
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room2D:
     .db     Area_MainDeck, 2Dh, 0
     .db     04h, 06h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room2E:
     .db     Area_MainDeck, 2Eh, 0
     .db     09h, 08h
     .db     Upgrade_InfantMetroid
     .db     UpgradeSprite_InfantMetroid
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room2F:
     .db     Area_MainDeck, 2Fh, 0
     .db     04h, 03h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room32:
     .db     Area_MainDeck, 32h, 0
     .db     36h, 08h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room33:
     .db     Area_MainDeck, 33h, 0
     .db     05h, 1Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room39:
     .db     Area_MainDeck, 39h, 0
     .db     0Ch, 0Ah
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room45:
     .db     Area_MainDeck, 45h, 0
     .db     1Dh, 1Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room47:
     .db     Area_MainDeck, 47h, 0
     .db     06h, 09h
     .db     Upgrade_InfantMetroid
     .db     UpgradeSprite_InfantMetroid
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room48:
     .db     Area_MainDeck, 48h, 0
     .db     0Dh, 09h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room49:
     .db     Area_MainDeck, 49h, 0
     .db     06h, 0Ah
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_MainDeck_Room54:
     .db     Area_MainDeck, 54h, 0
     .db     0Eh, 0Ah
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room05:
     .db     Area_SRX, 05h, 0
     .db     1Bh, 0Ah
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room11:
     .db     Area_SRX, 11h, 0
     .db     08h, 06h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_SRX, 11h, 1
     .db     19h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_SRX, 11h, 2
     .db     2Ch, 13h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room19:
     .db     Area_SRX, 19h, 0
     .db     0Fh, 08h ; REPLACE WHEN IMPLEMENTED
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room1E:
     .db     Area_SRX, 1Eh, 0
     .db     0Fh, 08h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room20:
     .db     Area_SRX, 20h, 0
     .db     1Dh, 09h
     .db     Upgrade_InfantMetroid
     .db     UpgradeSprite_InfantMetroid
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room27:
     .db     Area_SRX, 27h, 0
     .db     04h, 06h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room28:
     .db     Area_SRX, 28h, 0
     .db     0Ch, 08h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room2B:
     .db     Area_SRX, 2Bh, 0
     .db     0Dh, 0Bh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room2C:
     .db     Area_SRX, 2Ch, 0
     .db     04h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room2F:
     .db     Area_SRX, 2Fh, 0
     .db     0Ah, 02h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room32:
     .db     Area_SRX, 32h, 0
     .db     06h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector1_Room34:
     .db     Area_SRX, 34h, 0
     .db     0Dh, 07h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room06:
     .db     Area_TRO, 06h, 0
     .db     1Dh, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room09:
     .db     Area_TRO, 09h, 0
     .db     0Dh, 04h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room0A:
     .db     Area_TRO, 0Ah, 0
     .db     13h, 23h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room11:
     .db     Area_TRO, 11h, 0
     .db     2Ch, 07h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room15:
     .db     Area_TRO, 15h, 0
     .db     1Dh, 04h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room19:
     .db     Area_TRO, 19h, 0
     .db     04h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room1B:
     .db     Area_TRO, 1Bh, 0
     .db     1Ch, 07h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room1F:
     .db     Area_TRO, 1Fh, 0
     .db     28h, 07h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room21:
     .db     Area_TRO, 21h, 0
     .db     15h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room2A:
     .db     Area_TRO, 2Ah, 0
     .db     05h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room2F:
     .db     Area_TRO, 2Fh, 0
     .db     1Dh, 10h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room32:
     .db     Area_TRO, 32h, 0
     .db     03h, 07h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_TRO, 32h, 1
     .db     03h, 18h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room36:
     .db     Area_TRO, 36h, 0
     .db     04h, 05h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_TRO, 36h, 1
     .db     09h, 0Eh
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector2_Room37:
     .db     Area_TRO, 37h, 0
     .db     07h, 04h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_TRO, 37h, 1
     .db     0Ah, 1Ah
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room03:
     .db     Area_PYR, 03h, 0
     .db     2Ch, 0Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room06:
     .db     Area_PYR, 06h, 0
     .db     05h, 11h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room08:
     .db     Area_PYR, 08h, 0
     .db     09h, 09h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_PYR, 08h, 1
     .db     16h, 0Dh
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room09:
     .db     Area_PYR, 09h, 0
     .db     2Ah, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room0C:
     .db     Area_PYR, 0Ch, 0
     .db     0Ch, 19h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room13:
     .db     Area_PYR, 13h, 0
     .db     13h, 0Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_PYR, 13h, 1
     .db     2Bh, 0Ah
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room1C:
     .db     Area_PYR, 1Ch, 0
     .db     0Ch, 07h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_PYR, 1Ch, 1
     .db     24h, 1Bh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room1E:
     .db     Area_PYR, 1Eh, 0
     .db     04h, 0Dh
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room21:
     .db     Area_PYR, 21h, 0
     .db     0Fh, 0Ah
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room22:
     .db     Area_PYR, 22h, 0
     .db     0Ah, 0Fh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room23:
     .db     Area_PYR, 23h, 0
     .db     04h, 1Bh
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_PYR, 23h, 1
     .db     0Fh, 56h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector3_Room25:
     .db     Area_PYR, 25h, 0
     .db     0Fh, 03h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room06:
     .db     Area_AQA, 06h, 0
     .db     16h, 1Dh
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room0A:
     .db     Area_AQA, 0Ah, 0
     .db     0Ch, 1Dh
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room0D:
     .db     Area_AQA, 0Dh, 0
     .db     18h, 09h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_AQA, 0Dh, 1
     .db     26h, 0Fh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room0F:
     .db     Area_AQA, 0Fh, 0
     .db     2Ch, 05h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room11:
     .db     Area_AQA, 11h, 0
     .db     17h, 14h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room17:
     .db     Area_AQA, 17h, 0
     .db     39h, 13h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room18:
     .db     Area_AQA, 18h, 0
     .db     28h, 07h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room1C:
     .db     Area_AQA, 1Ch, 0
     .db     09h, 06h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room21:
     .db     Area_AQA, 21h, 0
     .db     0Ah, 0Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room24:
     .db     Area_AQA, 24h, 0
     .db     03h, 07h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room26:
     .db     Area_AQA, 26h, 0
     .db     16h, 0Ah
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_AQA, 26h, 1
     .db     2Ah, 05h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room29:
     .db     Area_AQA, 29h, 0
     .db     0Fh, 04h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector4_Room2E:
     .db     Area_AQA, 2Eh, 0
     .db     04h, 0Ah
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room04:
     .db     Area_ARC, 04h, 0
     .db     05h, 05h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_ARC, 04h, 1
     .db     14h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room0C:
     .db     Area_ARC, 0Ch, 0
     .db     03h, 0Ah
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room0E:
     .db     Area_ARC, 0Eh, 0
     .db     0Dh, 03h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room12:
     .db     Area_ARC, 12h, 0
     .db     03h, 03h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room16:
     .db     Area_ARC, 16h, 0
     .db     03h, 30h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room17:
     .db     Area_ARC, 17h, 0
     .db     0Eh, 06h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room1A:
     .db     Area_ARC, 1Ah, 0
     .db     04h, 06h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room1E:
     .db     Area_ARC, 1Eh, 0
     .db     17h, 07h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room21:
     .db     Area_ARC, 21h, 0
     .db     0Eh, 03h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room22:
     .db     Area_ARC, 22h, 0
     .db     0Eh, 08h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room24:
     .db     Area_ARC, 24h, 0
     .db     08h, 08h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room2F:
     .db     Area_ARC, 2Fh, 0
     .db     04h, 0Ah
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room32:
     .db     Area_ARC, 32h, 0
     .db     0Dh, 08h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector5_Room33:
     .db     Area_ARC, 33h, 0
     .db     0Bh, 03h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room00:
     .db     Area_NOC, 00h, 0
     .db     29h, 12h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room0F:
     .db     Area_NOC, 0Fh, 0
     .db     03h, 03h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room12:
     .db     Area_NOC, 12h, 0
     .db     0Fh, 03h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_NOC, 12h, 1
     .db     1Dh, 14h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room18:
     .db     Area_NOC, 18h, 0
     .db     1Dh, 09h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room1A:
     .db     Area_NOC, 1Ah, 0
     .db     05h, 06h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room1E:
     .db     Area_NOC, 1Eh, 0
     .db     09h, 0Dh
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_NOC, 1Eh, 1
     .db     13h, 08h
     .db     Upgrade_MissileTank
     .db     UpgradeSprite_MissileTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room22:
     .db     Area_NOC, 22h, 0
     .db     0Eh, 08h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room26:
     .db     Area_NOC, 26h, 0
     .db     2Dh, 06h
     .db     Upgrade_EnergyTank
     .db     UpgradeSprite_EnergyTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 @Items_Sector6_Room27:
     .db     Area_NOC, 27h, 0
     .db     0Ah, 18h
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
     .db     Area_NOC, 27h, 1
     .db     21h, 0Ah
     .db     Upgrade_PowerBombTank
     .db     UpgradeSprite_PowerBombTank
-    .db     Message_Auto
+    .db     Message_Auto, MinorItemJingle
+    .fill   07h, 0
 .endautoregion
 
 .org MinorLocationsPointer

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -184,58 +184,6 @@
 .endfunc
 .endarea
 
-.org 0802AAAEh
-.area 06h
-    bl  SetMajorLocationMessageBoxTimer
-    nop
-.endarea
-
-.org 0802AB04h
-.area 04h
-    bl  SetMinorLocationMessageBoxTimer
-.endarea
-
-.autoregion
-.func SetMajorLocationMessageBoxTimer
-    ldr     r4, =ItemJingleFlag
-    ldrb    r0, [r4]
-    cmp     r0, #0
-    beq     @@minorJingle
-    ; prolong major item fanfare so it can't interrupt audio clips
-    ; last resort solution, but prevents several audio related bugs
-    mov     r0, #410 >> 1
-    lsl     r0, #1
-    b       @@return
-@@minorJingle:
-    mov     r0, #05Ah
-@@return:    
-    ldr     r4, =CurrentSprite
-    strh    r0, [r4, Sprite_XParasiteTimer]
-    bx      lr
-.endfunc
-.pool
-.endautoregion
-
-.autoregion
-.func SetMinorLocationMessageBoxTimer
-    ldr     r1, =ItemJingleFlag
-    ldrb    r0, [r1]
-    cmp     r0, #0
-    beq     @@minorJingle
-    ; prolong major item fanfare so it can't interrupt audio clips
-    ; last resort solution, but prevents several audio related bugs
-    mov     r0, #410 >> 1
-    lsl     r0, #1
-    b       @@return
-@@minorJingle:
-    mov     r0, #05Ah
-@@return:
-    ldr     r1, =CurrentSprite
-    mov     pc, lr
-.endfunc
-.pool
-.endautoregion
-
 ; Obtain upgrade from tank and set message and fanfare
 .org 0806C3CEh
 .area 1Ah

--- a/src/randomizer/tank-majors.s
+++ b/src/randomizer/tank-majors.s
@@ -185,12 +185,56 @@
 .endarea
 
 .org 0802AAAEh
+.area 06h
+    bl  SetMajorLocationMessageBoxTimer
+    nop
+.endarea
+
+.org 0802AB04h
 .area 04h
+    bl  SetMinorLocationMessageBoxTimer
+.endarea
+
+.autoregion
+.func SetMajorLocationMessageBoxTimer
+    ldr     r4, =ItemJingleFlag
+    ldrb    r0, [r4]
+    cmp     r0, #0
+    beq     @@minorJingle
     ; prolong major item fanfare so it can't interrupt audio clips
     ; last resort solution, but prevents several audio related bugs
     mov     r0, #410 >> 1
     lsl     r0, #1
-.endarea
+    b       @@return
+@@minorJingle:
+    mov     r0, #05Ah
+@@return:    
+    ldr     r4, =CurrentSprite
+    strh    r0, [r4, Sprite_XParasiteTimer]
+    bx      lr
+.endfunc
+.pool
+.endautoregion
+
+.autoregion
+.func SetMinorLocationMessageBoxTimer
+    ldr     r1, =ItemJingleFlag
+    ldrb    r0, [r1]
+    cmp     r0, #0
+    beq     @@minorJingle
+    ; prolong major item fanfare so it can't interrupt audio clips
+    ; last resort solution, but prevents several audio related bugs
+    mov     r0, #410 >> 1
+    lsl     r0, #1
+    b       @@return
+@@minorJingle:
+    mov     r0, #05Ah
+@@return:
+    ldr     r1, =CurrentSprite
+    mov     pc, lr
+.endfunc
+.pool
+.endautoregion
 
 ; Obtain upgrade from tank and set message and fanfare
 .org 0806C3CEh


### PR DESCRIPTION
Adds the infrastructure to specify location jingles. Currently all minor locations will default to the minor "Item Obtained", and all major locations to the long Upgrade Acquired jingle.

Closes #173 