### PR TITLE
Fix beam and missile graphics sometimes not getting reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased - 2025-XX-XX
+- Fixed: Weapon graphics sometimes did not reload after upgrades were collected/given.
 
 ## 0.7.2 - 2025-07-15
 - Fixed: Major item jingle can no longer be canceled.

--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -718,3 +718,5 @@ ItemJingleFlag equ 03005670h
 MinorItemJingle equ 0
 MajorItemJingle equ 1
 .sym on
+
+ReloadWeaponGfxFlag equ 03005671h

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -345,7 +345,7 @@
 .func @InGameSubroutineHighjack
     push    { lr }
     bl      CheckReloadWeaponGfx
-    bl      080819ECh
+    bl      080819ECh ; Restore vanilla function call (ProjectileDrawAll_True)
     pop     { r0 }
     bx      r0
 .endfunc

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -327,6 +327,8 @@
 
     bl      LoadBeamGfx
     bl      LoadMissileGfx
+    mov     r0, #0
+    strb    r0, [r1]
 @@return:
     pop     { pc }
     .pool

--- a/src/nonlinear/common.s
+++ b/src/nonlinear/common.s
@@ -183,6 +183,9 @@
     bl      IncrementPBCount
     mov     r0, #Upgrade_PowerBombs
 @@obtainMajor:
+    ldr     r4, =ReloadWeaponGfxFlag
+    mov     r3, #1
+    strb    r3, [r4]
     ldr     r4, =MajorUpgradeInfo
     lsl     r0, #2
     add     r4, r0
@@ -313,6 +316,36 @@
     mov     r0, #0
     pop     { r3, pc }
     .pool
+.endfunc
+
+.func CheckReloadWeaponGfx
+    push    { lr }
+    ldr     r1, =ReloadWeaponGfxFlag
+    ldrb    r0, [r1]
+    cmp     r0, #0
+    beq     @@return
+
+    bl      LoadBeamGfx
+    bl      LoadMissileGfx
+@@return:
+    pop     { pc }
+    .pool
+.endfunc
+.endautoregion
+
+.org 0800DF38h
+.area 4
+    bl  @InGameSubroutineHighjack
+.endarea
+
+.autoregion
+.align 2
+.func @InGameSubroutineHighjack
+    push    { lr }
+    bl      CheckReloadWeaponGfx
+    bl      080819ECh
+    pop     { r0 }
+    bx      r0
 .endfunc
 .endautoregion
 


### PR DESCRIPTION
Fixes #297

Adds a new flag to allow updating missile and beam graphics. This will allow gfx to be updated while the room is still loaded arbitrarily and not only when picking up items.

This also allows Multiworld (when the time comes) to manually edit a RAM address so beam GFX can be reloaded after the item has been received.