### PR TITLE
Slightly modify exit distance of doors with Gadora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2025-XX-XX
 - Fixed: Weapon graphics sometimes did not reload after upgrades were collected/given.
 - Fixed: Custom starting health displays incorrectly on a new file when you have not saved.
+- Changed: Doors with Gadora on them have had their exit distance tweaked to prevent damage when traversing from the opposite side.
 
 ### Room Adjustments
 - Removed: Removed the ANTI-SOFTLOCK conditional and instead made the changes always mandatory. This affects:

--- a/inc/enums.inc
+++ b/inc/enums.inc
@@ -679,4 +679,7 @@ AltTankPalD equ 27FFh
 AltTankPalE equ 0013h
 AltTankPalF equ 043Fh
 
+GadoraExitDistance_Right equ 23h
+GadoraExitDistance_Left equ 100h - 23h
+
 .sym on

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -103,7 +103,6 @@
 .include "src/nonlinear/room-edits/sector-6/scrolls.s"
 .include "src/nonlinear/room-edits/sector-6/room-07.s"
 .include "src/nonlinear/room-edits/sector-6/room-0C.s"
-.include "src/nonlinear/room-edits/sector-6/room-0F.s"
 .include "src/nonlinear/room-edits/sector-6/room-10.s"
 .include "src/nonlinear/room-edits/sector-6/room-18.s"
 .include "src/nonlinear/room-edits/sector-6/room-1B.s"

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -23,6 +23,7 @@
 .include "src/nonlinear/room-edits/main-deck/room-29-2A.s"
 .include "src/nonlinear/room-edits/main-deck/room-30.s"
 .include "src/nonlinear/room-edits/main-deck/room-31-3B.s"
+.include "src/nonlinear/room-edits/main-deck/room-33.s"
 .include "src/nonlinear/room-edits/main-deck/room-47.s"
 .include "src/nonlinear/room-edits/main-deck/room-52.s"
 .include "src/nonlinear/room-edits/main-deck/room-56.s"
@@ -35,6 +36,8 @@
 .include "src/nonlinear/room-edits/sector-1/room-0C.s"
 .include "src/nonlinear/room-edits/sector-1/room-0F.s"
 .include "src/nonlinear/room-edits/sector-1/room-14.s"
+.include "src/nonlinear/room-edits/sector-1/room-1A.s"
+.include "src/nonlinear/room-edits/sector-1/room-25.s"
 .include "src/nonlinear/room-edits/sector-1/room-26.s"
 .include "src/nonlinear/room-edits/sector-1/room-2E.s"
 
@@ -63,11 +66,13 @@
 .include "src/nonlinear/room-edits/sector-3/room-03.s"
 .include "src/nonlinear/room-edits/sector-3/room-06-18.s"
 .include "src/nonlinear/room-edits/sector-3/room-07-16.s"
+.include "src/nonlinear/room-edits/sector-3/room-11.s"
 .include "src/nonlinear/room-edits/sector-3/room-12-17.s"
 
 
 ; Sector 4 (AQA) Changes
 .include "src/nonlinear/room-edits/sector-4/room-06.s"
+.include "src/nonlinear/room-edits/sector-4/room-0A.s"
 .include "src/nonlinear/room-edits/sector-4/room-0D.s"
 .include "src/nonlinear/room-edits/sector-4/room-15.s"
 .include "src/nonlinear/room-edits/sector-4/room-16.s"
@@ -86,6 +91,7 @@
 .include "src/nonlinear/room-edits/sector-5/room-07-0F.s"
 .include "src/nonlinear/room-edits/sector-5/room-08.s"
 .include "src/nonlinear/room-edits/sector-5/room-0D-2C.s"
+.include "src/nonlinear/room-edits/sector-5/room-13.s"
 .include "src/nonlinear/room-edits/sector-5/room-15-16.s"
 .include "src/nonlinear/room-edits/sector-5/room-1A.s"
 .include "src/nonlinear/room-edits/sector-5/room-24.s"
@@ -96,6 +102,8 @@
 ; Sector 6 (NOC) Changes
 .include "src/nonlinear/room-edits/sector-6/scrolls.s"
 .include "src/nonlinear/room-edits/sector-6/room-07.s"
+.include "src/nonlinear/room-edits/sector-6/room-0C.s"
+.include "src/nonlinear/room-edits/sector-6/room-0F.s"
 .include "src/nonlinear/room-edits/sector-6/room-10.s"
 .include "src/nonlinear/room-edits/sector-6/room-18.s"
 .include "src/nonlinear/room-edits/sector-6/room-1B.s"

--- a/src/nonlinear/room-edits.s
+++ b/src/nonlinear/room-edits.s
@@ -12,6 +12,7 @@
 .include "src/nonlinear/room-edits/main-deck/scrolls.s"
 .include "src/nonlinear/room-edits/main-deck/room-06.s"
 .include "src/nonlinear/room-edits/main-deck/room-0A.s"
+.include "src/nonlinear/room-edits/main-deck/room-0C.s"
 .include "src/nonlinear/room-edits/main-deck/room-0D-4A-55.s"
 .include "src/nonlinear/room-edits/main-deck/room-12.s"
 .include "src/nonlinear/room-edits/main-deck/room-14-and-2E.s"

--- a/src/nonlinear/room-edits/main-deck/room-0A.s
+++ b/src/nonlinear/room-edits/main-deck/room-0A.s
@@ -1,0 +1,7 @@
+; Main Deck - Crew Quarters East
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
+.endarea

--- a/src/nonlinear/room-edits/main-deck/room-0A.s
+++ b/src/nonlinear/room-edits/main-deck/room-0A.s
@@ -1,5 +1,7 @@
 ; Main Deck - Crew Quarters West
 ; remove power bomb geron
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
 .defineregion readptr(MainDeckLevels + 0Ch * LevelMeta_Size + LevelMeta_Spriteset1), 0Fh
 
 .org MainDeckLevels + 0Ch * LevelMeta_Size + LevelMeta_Spriteset1Event
@@ -12,4 +14,9 @@
     .skip 2
     .dw     NullSpriteset
     .db     0
+.endarea
+
+.org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
 .endarea

--- a/src/nonlinear/room-edits/main-deck/room-0A.s
+++ b/src/nonlinear/room-edits/main-deck/room-0A.s
@@ -3,5 +3,5 @@
 
 .org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/main-deck/room-0A.s
+++ b/src/nonlinear/room-edits/main-deck/room-0A.s
@@ -1,4 +1,4 @@
-; Main Deck - Crew Quarters West
+; Main Deck - Crew Quarters East
 ; remove power bomb geron
 ; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
 

--- a/src/nonlinear/room-edits/main-deck/room-0C.s
+++ b/src/nonlinear/room-edits/main-deck/room-0C.s
@@ -1,6 +1,5 @@
-; Main Deck - Crew Quarters East
+; Main Deck - Crew Quarters West
 ; remove power bomb geron
-; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
 
 .defineregion readptr(MainDeckLevels + 0Ch * LevelMeta_Size + LevelMeta_Spriteset1), 0Fh
 
@@ -14,9 +13,4 @@
     .skip 2
     .dw     NullSpriteset
     .db     0
-.endarea
-
-.org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
-.area 1
-    .db     100h - 23h
 .endarea

--- a/src/nonlinear/room-edits/main-deck/room-33.s
+++ b/src/nonlinear/room-edits/main-deck/room-33.s
@@ -1,0 +1,7 @@
+; Main Deck - Silo Scaffolding
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     23h
+.endarea

--- a/src/nonlinear/room-edits/main-deck/room-33.s
+++ b/src/nonlinear/room-edits/main-deck/room-33.s
@@ -1,7 +1,7 @@
 ; Main Deck - Silo Scaffolding
 ; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
 
-.org MainDeckDoors + 56h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.org MainDeckDoors + 75h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
     .db     23h
 .endarea

--- a/src/nonlinear/room-edits/main-deck/room-33.s
+++ b/src/nonlinear/room-edits/main-deck/room-33.s
@@ -3,5 +3,5 @@
 
 .org MainDeckDoors + 75h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     23h
+    .db     GadoraExitDistance_Right
 .endarea

--- a/src/nonlinear/room-edits/sector-1/room-1A.s
+++ b/src/nonlinear/room-edits/sector-1/room-1A.s
@@ -1,0 +1,7 @@
+; Sector 1 - Ridley Arena Access
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector1Doors + 39h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     23h
+.endarea

--- a/src/nonlinear/room-edits/sector-1/room-1A.s
+++ b/src/nonlinear/room-edits/sector-1/room-1A.s
@@ -3,5 +3,5 @@
 
 .org Sector1Doors + 39h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     23h
+    .db     GadoraExitDistance_Right
 .endarea

--- a/src/nonlinear/room-edits/sector-1/room-25.s
+++ b/src/nonlinear/room-edits/sector-1/room-25.s
@@ -3,5 +3,5 @@
 
 .org Sector1Doors + 53h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     23h
+    .db     GadoraExitDistance_Right
 .endarea

--- a/src/nonlinear/room-edits/sector-1/room-25.s
+++ b/src/nonlinear/room-edits/sector-1/room-25.s
@@ -1,0 +1,7 @@
+; Sector 1 - Charge Core Lower Access
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector1Doors + 53h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     23h
+.endarea

--- a/src/nonlinear/room-edits/sector-2/room-11.s
+++ b/src/nonlinear/room-edits/sector-2/room-11.s
@@ -72,5 +72,5 @@
 
 .org Sector2Doors + 27h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/sector-2/room-11.s
+++ b/src/nonlinear/room-edits/sector-2/room-11.s
@@ -1,5 +1,7 @@
 ; Sector 2 - Zazabi Arena Access
 ; add cocoon and kihunter spritesets to intact room state
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
 .autoregion
 @S2_ZazabiAccess_Spriteset1:
     .db     03h, 27h, 12h
@@ -66,4 +68,9 @@
 .area 08h
     .dw     @S2_ZazabiAccess_CocoonSpriteset
     .dw     @S2_ZazabiAccess_KihunterSpriteset
+.endarea
+
+.org Sector2Doors + 27h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
 .endarea

--- a/src/nonlinear/room-edits/sector-2/room-14-22.s
+++ b/src/nonlinear/room-edits/sector-2/room-14-22.s
@@ -25,5 +25,5 @@
 
 .org Sector2Doors + 30h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/sector-2/room-14-22.s
+++ b/src/nonlinear/room-edits/sector-2/room-14-22.s
@@ -1,6 +1,8 @@
 ; Sector 2 - Nettori Access
 ; change winged kihunter below eyedoor into a grounded kihunter
 ; remove 4 tiles to prevent the above kihunter from jumping through solids
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
 .org readptr(Sector2Levels + 14h * LevelMeta_Size + LevelMeta_Bg1)
 .area 4F6h
 .incbin "data/rooms/S2-14-BG1.rlebg"
@@ -19,4 +21,9 @@
 .org readptr(Sector2Levels + 22h * LevelMeta_Size + LevelMeta_Spriteset0) + 2 * 3
 .area 3
     .db     11h, 15h, 26h
+.endarea
+
+.org Sector2Doors + 30h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
 .endarea

--- a/src/nonlinear/room-edits/sector-3/room-11.s
+++ b/src/nonlinear/room-edits/sector-3/room-11.s
@@ -3,5 +3,5 @@
 
 .org Sector3Doors + 31h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     23h
+    .db     GadoraExitDistance_Right
 .endarea

--- a/src/nonlinear/room-edits/sector-3/room-11.s
+++ b/src/nonlinear/room-edits/sector-3/room-11.s
@@ -1,0 +1,7 @@
+; Sector 3 - Main Boiler
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector3Doors + 31h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     23h
+.endarea

--- a/src/nonlinear/room-edits/sector-4/room-0A.s
+++ b/src/nonlinear/room-edits/sector-4/room-0A.s
@@ -1,0 +1,7 @@
+; Sector 4 - Broken Bridge
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector4Doors + 40h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
+.endarea

--- a/src/nonlinear/room-edits/sector-4/room-0A.s
+++ b/src/nonlinear/room-edits/sector-4/room-0A.s
@@ -3,5 +3,5 @@
 
 .org Sector4Doors + 40h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/sector-5/room-13.s
+++ b/src/nonlinear/room-edits/sector-5/room-13.s
@@ -1,0 +1,7 @@
+; Sector 5 - Nightmare Upper Access
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector5Doors + 26h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
+.endarea

--- a/src/nonlinear/room-edits/sector-5/room-13.s
+++ b/src/nonlinear/room-edits/sector-5/room-13.s
@@ -3,5 +3,5 @@
 
 .org Sector5Doors + 26h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/sector-6/room-0C.s
+++ b/src/nonlinear/room-edits/sector-6/room-0C.s
@@ -3,5 +3,5 @@
 
 .org Sector6Doors + 18h * DoorEntry_Size + DoorEntry_ExitDistanceX
 .area 1
-    .db     100h - 23h
+    .db     GadoraExitDistance_Left
 .endarea

--- a/src/nonlinear/room-edits/sector-6/room-0C.s
+++ b/src/nonlinear/room-edits/sector-6/room-0C.s
@@ -1,0 +1,7 @@
+; Sector 6 - Data Access
+; Slightly adjust exit-distance from door with gadora to prevent instant damage if the gadora is not defeated.
+
+.org Sector6Doors + 18h * DoorEntry_Size + DoorEntry_ExitDistanceX
+.area 1
+    .db     100h - 23h
+.endarea


### PR DESCRIPTION
Fixes #299

This ever so slightly adjusts the exit distance of doors with Gadora on them by 3 pixels to avoid being damaged by them when traversing from the opposite side.