### PR TITLE
Fix overlapping RAM Values

### DIFF
--- a/inc/structs.inc
+++ b/inc/structs.inc
@@ -704,19 +704,34 @@ PrimarySpriteAiPtrs equ 0879A29Ch
 SpriteGfxPtrs equ 0879A5D8h
 SpritePalettePtrs equ 0879A8D4h
 
-StoredRevealedTiles equ 03005630h
+
+; Store structs for new Memory Here
 .sym off
+;StoredRevealedTiles
 StoredRevealedTiles_Len equ 40h
 StoredRevealedTiles_Type equ 0
 StoredRevealedTiles_YPos equ 2
 StoredRevealedTiles_XPos equ 3
 StoredRevealedTiles_Size equ 4
-.sym on
 
-ItemJingleFlag equ 03005670h
-.sym off
+;ItemJingleFlag
 MinorItemJingle equ 0
 MajorItemJingle equ 1
 .sym on
 
-ReloadWeaponGfxFlag equ 03005671h
+; Add Label for new memory location here, align if necessary.
+; Use `.skip <length>` to automatically allocate memory without overlap.
+.headersize 03000000h
+.org FreeIWRam
+    .align 4
+StoredRevealedTiles:
+    .skip StoredRevealedTiles_Len * StoredRevealedTiles_Size
+
+ItemJingleFlag:
+    .skip 1
+
+ReloadWeaponGfxFlag:
+    .skip 1
+
+.headersize 08000000h
+.org 08000000h

--- a/src/main.s
+++ b/src/main.s
@@ -39,6 +39,10 @@
 .definelabel UNHIDDEN_MAP_DOORS, 0
 .endif
 
+FreeIWRam equ 03005630h
+FreeIWRamLen equ 23D0h
+FreeIWRamEnd equ FreeIWRam + FreeIWRamLen ; ends 030079FFh
+
 .include "inc/constants.inc"
 .include "inc/enums.inc"
 .include "inc/functions.inc"


### PR DESCRIPTION
This new layout means we won't be hardcoding memory addresses for newly allocated memory, but it also means that the memory address is not visible outside of the assembler. The addresses are predictable, but they are not output anywhere with this setup and must be calculated based on the `.skip`s being used.

Fixes #309 