### PR TITLE
Port stereo-default IPS patch from patcher into ASM as a flag in ROM

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -69,6 +69,8 @@ Sprite_MakesDebrisWhenHit equ 08082FECh
 Sprite_CreateDebris equ 08083090h
 Sprite_CreatePlasmaDebris equ 080831C4h
 
+FileSelectDrawAllOam equ 080A1208h
+
 Divide equ 080A3468h
 memcpy equ 080A4EF0h
 memset equ 080A4F50h

--- a/src/main.s
+++ b/src/main.s
@@ -4,6 +4,7 @@
 .table "data/text.tbl"
 
 ; Assembly-time flags
+.sym off
 .ifndef DEBUG
 .definelabel DEBUG, 1
 .endif
@@ -38,6 +39,7 @@
 .ifndef UNHIDDEN_MAP_DOORS
 .definelabel UNHIDDEN_MAP_DOORS, 0
 .endif
+.sym on
 
 FreeIWRam equ 03005630h
 FreeIWRamLen equ 23D0h
@@ -77,6 +79,7 @@ MissileLimitPointer             equ 087FF024h
 RoomNamesPointer                equ 087FF028h
 RevealHiddenTilesFlagPointer    equ 087FF02Ch
 TitleScreenTextPointersPointer  equ 087FF030h
+DefaultStereoFlagPointer        equ 087FF034h
 
 
 ; Mark end-of-file padding as free space
@@ -87,9 +90,6 @@ DataFreeSpace equ 080F9A28h
 DataFreeSpaceLen equ 20318h
 DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .defineregion DataFreeSpace, DataFreeSpaceLen, 0FFh
-.autoregion DataFreeSpace, DataFreeSpaceEnd
-    .skip 0FFh ; Reserve space for stereo_default IPS patch from patcher
-.endautoregion
 
 ; Debug mode patch
 .if DEBUG
@@ -114,6 +114,7 @@ DataFreeSpaceEnd equ DataFreeSpace + DataFreeSpaceLen
 .include "src/qol/aim-lock.s"
 .include "src/qol/completion-seconds.s"
 .include "src/qol/cross-sector-maps.s"
+.include "src/qol/stereo-default.s"
 .include "src/qol/fast-doors.s"
 .include "src/qol/fast-elevators.s"
 .include "src/qol/ice-beam-volume.s"

--- a/src/qol/stereo-default.s
+++ b/src/qol/stereo-default.s
@@ -1,0 +1,76 @@
+/*  Sets the default speaker mode to Stereo
+*/
+.org DefaultStereoFlagPointer
+.area 4
+    .dw     DefaultStereoFlag
+.endarea
+
+.org 0809E8BAh
+; Modifying OAM setup in FileSelectInit()
+.area 4
+    bl      @FileSelectInitHighjack_SetupOam
+.endarea
+
+.org 0809E8DEh
+; Highjacks FileSelectInit(), enables stereo automatically
+.area 4
+    bl      @FileSelectInitHighjack_CheckEnableStereo
+.endarea
+
+.org 0809F670h
+; Highjacks FileSelectSetupOam()
+.area 4
+    bl      @FileSelectSetupOamHighjack
+.endarea
+
+.autoregion
+DefaultStereoFlag:
+    .db     00
+    .align 2
+@FileSelectInitHighjack_SetupOam:
+    mov     r1, #66h
+    ldr     r0, =DefaultStereoFlag
+    ldrb    r0, [r0]
+    cmp     r0, #01
+    bne     @@mono
+    mov     r1, #0AAh
+@@mono:
+    mov     r0, #09h
+    bx      lr
+    .pool
+
+@FileSelectSetupOamHighjack:
+    ; do not destroy r0
+    push    { r4 }
+    ldr     r1, =087407E0h
+    ldr     r4, =DefaultStereoFlag
+    ldrb    r4, [r4]
+    cmp     r4, #1
+    bne     @@mono
+    add     r1, #10h
+@@mono:
+    str     r1, [r0]
+    pop     { r4 }
+    bx      lr
+    .pool
+
+@FileSelectInitHighjack_CheckEnableStereo:
+    push    { lr }
+    ldr     r1, =DefaultStereoFlag
+    ldrb    r1, [r1]
+    cmp     r1, #1
+    bne     @@return
+    mov     r0, #01
+    ldr     r1, =030016E8h          ; Non-Gameplay Ram for File Select, Part of FileSelectOam
+    strb    r0, [r1, #09]
+    ldr     r1, =03001704h          ; Non-Gameplay Ram for File Select, Part of FileSelectOam
+    strb    r0, [r1, #09]
+    mov     r0, #02000000h >> 12h
+    lsl     r0, #12h
+    bl      080024ECh               ; takes 1 argument in r0
+@@return:
+    bl      FileSelectDrawAllOam    ; FileSelectDrawAllOam
+    pop     { r0 }
+    bx      r0
+    .pool
+.endautoregion


### PR DESCRIPTION
This obsoletes the need for the patcher to apply an arbitrary IPS file.
Patcher changes will be needed to compliment this PR.