### PR TITLE
Fix autoregion data potentially interfering with MinorLocations data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - 2025-??-??
+- Fixed: The upper item in Sector 6 - Spaceboost Alley would not load the correct information if assembled data after the Minor Locations data table contained a non-zero value for the next room index.
+
 
 ## 0.9.1- 2025-09-23
 

--- a/src/optimization/item-check.s
+++ b/src/optimization/item-check.s
@@ -1327,6 +1327,19 @@ MinorLocations:
     .db     UpgradeSprite_PowerBombTank
     .db     Message_Auto, MinorItemJingle
     .fill   07h, 0
+
+@EndOfMinorLocationsTable:
+/* Note
+This was added to fix an out of bounds read on the last item in the table. Other
+data can live directly next to the end of this table and the RemoveCollectedTanks
+function above only exits when the next item room index equals zero. When
+non-zero data lives after this table, there is the possibility that the offset
+for the room index check contains nonzero data causing the function to
+erroneously loop again.
+If you are adding any new locations to the game, do so in the appropriate area
+and room order above the @EndOfMinorLocationsTable label.
+*/
+    .fill   10h, 0
 .endautoregion
 
 .org MinorLocationsPointer


### PR DESCRIPTION
Fixes a bug reported by BigBradley (`braydenbra`) on discord.

Adds null data to end of the `MinorLocations` Table to fix an unintended out-of-bounds read error when other autoregion data placed after it contains information that may be processed by code.